### PR TITLE
Register com.jcraft.jsch.jzlib.Compression for reflection

### DIFF
--- a/deployment/src/main/java/io/quarkus/jsch/deployment/JSchProcessor.java
+++ b/deployment/src/main/java/io/quarkus/jsch/deployment/JSchProcessor.java
@@ -123,6 +123,7 @@ class JSchProcessor {
                 "com.jcraft.jsch.jce.TripleDESCBC",
                 "com.jcraft.jsch.jce.TripleDESCTR",
                 "com.jcraft.jsch.jgss.GSSContextKrb5",
+                "com.jcraft.jsch.jzlib.Compression",
                 "com.jcraft.jsch.UserAuthGSSAPIWithMIC",
                 "com.jcraft.jsch.UserAuthKeyboardInteractive",
                 "com.jcraft.jsch.UserAuthNone",

--- a/integration-tests/src/main/java/io/quarkus/it/jsch/JSchResource.java
+++ b/integration-tests/src/main/java/io/quarkus/it/jsch/JSchResource.java
@@ -33,4 +33,18 @@ public class JSchResource {
         KeyPair keyPair = KeyPair.load(new JSch(), privateKey, null);
         return keyPair.decrypt(passphrase);
     }
+
+    @GET
+    @Path("/zlib")
+    public Response zlib(@QueryParam("host") String host, @QueryParam("port") int port) throws Exception {
+        JSch jsch = new JSch();
+        Session session = jsch.getSession(null, host, port);
+        session.setConfig("StrictHostKeyChecking", "no");
+        session.setConfig("compression.c2s", "zlib@openssh.com,zlib");
+        session.setConfig("compression_level", Integer.toString(9));
+        session.connect();
+        String serverVersion = session.getServerVersion();
+        session.disconnect();
+        return Response.ok(serverVersion).build();
+    }
 }

--- a/integration-tests/src/test/java/io/quarkus/it/jsch/JSchTest.java
+++ b/integration-tests/src/test/java/io/quarkus/it/jsch/JSchTest.java
@@ -87,6 +87,16 @@ public class JSchTest {
                 .body(is("true"));
     }
 
+    @Test
+    void shouldSupportZLibCompression() {
+        given().queryParam("host", sshd.getHost())
+                .queryParam("port", sshd.getPort())
+                .get("/jsch/zlib")
+                .then()
+                .statusCode(is(200))
+                .body(endsWith(sshd.getVersion()));
+    }
+
     @AfterEach
     void stopServer() throws Exception {
         if (sshd != null) {


### PR DESCRIPTION
Fix for https://github.com/quarkiverse/quarkus-jsch/issues/118
The test is not super fancy, but it fails if the `com.jcraft.jsch.jzlib.Compression` class is missing.